### PR TITLE
Namespace commands with `zendesk` or `zd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ In hubot project repo, run:
 
 `npm install hubot-zendesk --save`
 
-Add **hubot-zendesk** to your `package.json` file:
-
-```javascript
-"dependencies": {
-  "hubot": ">= 2.5.1",
-  "hubot-zendesk": "*"
-}
-```
-
 Then add **hubot-zendesk** to your `external-scripts.json`:
 
 ```json
@@ -26,20 +17,23 @@ Then add **hubot-zendesk** to your `external-scripts.json`:
 ```
 
 # Configuration:
-```   HUBOT_ZENDESK_USER
-   HUBOT_ZENDESK_PASSWORD
-   HUBOT_ZENDESK_SUBDOMAIN
 ```
+HUBOT_ZENDESK_USER
+HUBOT_ZENDESK_PASSWORD
+HUBOT_ZENDESK_SUBDOMAIN
+```
+
 # Commands:
-```   hubot (all) tickets - returns the total count of all unsolved tickets. The 'all' keyword is optional.
-   hubot new tickets - returns the count of all new (unassigned) tickets
-   hubot open tickets - returns the count of all open tickets
-   hubot escalated tickets - returns a count of tickets with escalated tag that are open or pending
-   hubot pending tickets - returns a count of tickets that are pending
-   hubot list (all) tickets - returns a list of all unsolved tickets. The 'all' keyword is optional.
-   hubot list new tickets - returns a list of all new tickets
-   hubot list open tickets - returns a list of all open tickets
-   hubot list pending tickets - returns a list of pending tickets
-   hubot list escalated tickets - returns a list of escalated tickets
-   hubot ticket <ID> - returns information about the specified ticket
+```
+hubot zendesk (all) tickets - returns the total count of all unsolved tickets. The 'all' keyword is optional.
+hubot zendesk new tickets - returns the count of all new (unassigned) tickets
+hubot zendesk open tickets - returns the count of all open tickets
+hubot zendesk escalated tickets - returns a count of tickets with escalated tag that are open or pending
+hubot zendesk pending tickets - returns a count of tickets that are pending
+hubot zendesk list (all) tickets - returns a list of all unsolved tickets. The 'all' keyword is optional.
+hubot zendesk list new tickets - returns a list of all new tickets
+hubot zendesk list open tickets - returns a list of all open tickets
+hubot zendesk list pending tickets - returns a list of pending tickets
+hubot zendesk list escalated tickets - returns a list of escalated tickets
+hubot zendesk ticket <ID> - returns information about the specified ticket
 ```

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -7,17 +7,17 @@
 #   HUBOT_ZENDESK_SUBDOMAIN
 #
 # Commands:
-#   hubot (all) tickets - returns the total count of all unsolved tickets. The 'all' keyword is optional.
-#   hubot new tickets - returns the count of all new (unassigned) tickets
-#   hubot open tickets - returns the count of all open tickets
-#   hubot escalated tickets - returns a count of tickets with escalated tag that are open or pending
-#   hubot pending tickets - returns a count of tickets that are pending
-#   hubot list (all) tickets - returns a list of all unsolved tickets. The 'all' keyword is optional.
-#   hubot list new tickets - returns a list of all new tickets
-#   hubot list open tickets - returns a list of all open tickets
-#   hubot list pending tickets - returns a list of pending tickets
-#   hubot list escalated tickets - returns a list of escalated tickets
-#   hubot ticket <ID> - returns information about the specified ticket
+#   hubot zendesk (all) tickets - returns the total count of all unsolved tickets. The 'all' keyword is optional.
+#   hubot zendesk new tickets - returns the count of all new (unassigned) tickets
+#   hubot zendesk open tickets - returns the count of all open tickets
+#   hubot zendesk escalated tickets - returns a count of tickets with escalated tag that are open or pending
+#   hubot zendesk pending tickets - returns a count of tickets that are pending
+#   hubot zendesk list (all) tickets - returns a list of all unsolved tickets. The 'all' keyword is optional.
+#   hubot zendesk list new tickets - returns a list of all new tickets
+#   hubot zendesk list open tickets - returns a list of all open tickets
+#   hubot zendesk list pending tickets - returns a list of pending tickets
+#   hubot zendesk list escalated tickets - returns a list of escalated tickets
+#   hubot zendesk ticket <ID> - returns information about the specified ticket
 
 sys = require 'sys' # Used for debugging
 tickets_url = "https://#{process.env.HUBOT_ZENDESK_SUBDOMAIN}.zendesk.com/tickets"
@@ -66,64 +66,66 @@ zendesk_user = (msg, user_id) ->
 
 module.exports = (robot) ->
 
-  robot.respond /(all )?tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) (all )?tickets$/i, (msg) ->
     zendesk_request msg, queries.unsolved, (results) ->
       ticket_count = results.count
       msg.send "#{ticket_count} unsolved tickets"
 
-  robot.respond /pending tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) pending tickets$/i, (msg) ->
     zendesk_request msg, queries.pending, (results) ->
       ticket_count = results.count
       msg.send "#{ticket_count} unsolved tickets"
 
-  robot.respond /new tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) new tickets$/i, (msg) ->
     zendesk_request msg, queries.new, (results) ->
       ticket_count = results.count
       msg.send "#{ticket_count} new tickets"
 
-  robot.respond /escalated tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) escalated tickets$/i, (msg) ->
     zendesk_request msg, queries.escalated, (results) ->
       ticket_count = results.count
       msg.send "#{ticket_count} escalated tickets"
 
-  robot.respond /open tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) open tickets$/i, (msg) ->
     zendesk_request msg, queries.open, (results) ->
       ticket_count = results.count
       msg.send "#{ticket_count} open tickets"
 
-  robot.respond /list (all )?tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) list (all )?tickets$/i, (msg) ->
     zendesk_request msg, queries.unsolved, (results) ->
       for result in results.results
         msg.send "Ticket #{result.id} is #{result.status}: #{tickets_url}/#{result.id}"
 
-  robot.respond /list new tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) list new tickets$/i, (msg) ->
     zendesk_request msg, queries.new, (results) ->
       for result in results.results
         msg.send "Ticket #{result.id} is #{result.status}: #{tickets_url}/#{result.id}"
 
-  robot.respond /list pending tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) list pending tickets$/i, (msg) ->
     zendesk_request msg, queries.pending, (results) ->
       for result in results.results
         msg.send "Ticket #{result.id} is #{result.status}: #{tickets_url}/#{result.id}"
 
-  robot.respond /list escalated tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) list escalated tickets$/i, (msg) ->
     zendesk_request msg, queries.escalated, (results) ->
       for result in results.results
         msg.send "Ticket #{result.id} is escalated and #{result.status}: #{tickets_url}/#{result.id}"
 
-  robot.respond /list open tickets$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) list open tickets$/i, (msg) ->
     zendesk_request msg, queries.open, (results) ->
       for result in results.results
         msg.send "Ticket #{result.id} is #{result.status}: #{tickets_url}/#{result.id}"
 
-  robot.respond /ticket ([\d]+)$/i, (msg) ->
+  robot.respond /(?:zendesk|zd) ticket ([\d]+)$/i, (msg) ->
     ticket_id = msg.match[1]
     zendesk_request msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
       if result.error
         msg.send result.description
         return
       message = "#{tickets_url}/#{result.ticket.id} ##{result.ticket.id} (#{result.ticket.status.toUpperCase()})"
-      message += "\nUpdated: #{result.ticket.updated_at}"
-      message += "\nAdded: #{result.ticket.created_at}"
-      message += "\nDescription:\n-------\n#{result.ticket.description}\n--------"
+      message += "\n>Updated: #{result.ticket.updated_at}"
+      message += "\n>Added: #{result.ticket.created_at}"
+      message += "\n>Description:"
+      message += "\n>-------"
+      message += "\n>#{result.ticket.description}"
       msg.send message

--- a/test/zendesk-test.coffee
+++ b/test/zendesk-test.coffee
@@ -12,8 +12,32 @@ describe 'zendesk', ->
 
     require('../src/zendesk')(@robot)
 
-  it 'registers a respond listener', ->
-    expect(@robot.respond).to.have.been.calledWith(/hello/)
+  it 'registers a respond listener for all ticket count', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) (all )?tickets$/i)
 
-  it 'registers a hear listener', ->
-    expect(@robot.hear).to.have.been.calledWith(/orly/)
+  it 'registers a respond listener for pending ticket count', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) pending tickets$/i)
+
+  it 'registers a respond listener for new ticket count', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) new tickets$/i)
+
+  it 'registers a respond listener for escalated ticket count', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) escalated tickets$/i)
+
+  it 'registers a respond listener for open ticket count', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) open tickets$/i)
+
+  it 'registers a respond listener for new ticket list', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) list new tickets$/i)
+
+  it 'registers a respond listener for pending ticket list', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) list pending tickets$/i)
+
+  it 'registers a respond listener for escalated ticket list', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) list escalated tickets$/i)
+
+  it 'registers a respond listener for open tickets list', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) list open tickets$/i)
+
+  it 'registers a respond listener for ticket view', ->
+    expect(@robot.respond).to.have.been.calledWith(/(?:zendesk|zd) ticket ([\d]+)$/i)


### PR DESCRIPTION
We run multiple :hubot: packages and have found it eaiser to look up the commands and run them in a non-conflicting way if we add a keyword describing the service to the front of it. So for example:

`hubot tickets`

becomes:

`hubot zendesk tickets`

With the use of an alias, such as `!`, it shortens it up nicer to where the command is more directly relatable:

`!zendesk tickets`

At any rate, this PR is a suggestion. It obviously breaks userspace, but it will not effect anyoen that used the `npm install hubot-zendesk --save` method, as that will lock it down to a particular version.

**Other changes:**

- Wired up the test suite so you could hook it into Travis easily (`npm test`)
- Removed the redundant note about adding it to package.json. Running the `--save` method described above already does that for you.
- Adjusted some code formatting in the README