### PR TITLE
LICENSE, Output Formatting, listener

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-T License
-
+hubot-zendesk - hubot plugin for zendesk
 Copyright (c) 2017 William Beckett
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+T License
+
+Copyright (c) 2017 William Beckett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Then add **hubot-zendesk** to your `external-scripts.json`:
 HUBOT_ZENDESK_USER
 HUBOT_ZENDESK_PASSWORD
 HUBOT_ZENDESK_SUBDOMAIN
+HUBOT_ZENDESK_LISTEN
 ```
 
 # Commands:

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -159,7 +159,7 @@ module.exports = (robot) ->
       message += "\n>#{result.ticket.description}"
       msg.send message
 
-  robot.hear /#([\d+)/i, (msg) ->
+  robot.hear /#([\d]+)/i, (msg) ->
     ticket_id = msg.match[1]
     zendesk_request_hear msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
       if result.error

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -129,3 +129,16 @@ module.exports = (robot) ->
       message += "\n>-------"
       message += "\n>#{result.ticket.description}"
       msg.send message
+
+  robot.hear /#([\d+)$/i, (msg) ->
+    ticket_id = msg.match[1]
+    zendesk_requst msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
+      if result.error
+        msg.send "Hmmm. I thought you were talking about a zendesk ticket, but when I tried looking it up, I got an error: #{result.description}"
+        return
+      message = "It sounds like you're referencing a zendesk ticket, let me look that up for you..."
+      message += "\n{tickets_url}/#{result.ticket.id} ##{result.ticket.id} (#{result.ticket.status.toUpperCase()})"
+      message += "\n>Updated: #{result.ticket.updated_at}"
+      message += "\n>Added: #{result.ticket.created_at}"
+      message += "\n>Description: #{result.ticket.description}"
+

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -153,7 +153,7 @@ module.exports = (robot) ->
         msg.send result.description
         return
       message = "#{tickets_url}/#{result.ticket.id}"
-      message += "\n>##{result.ticket.id} #(result.ticket.subject) (#{result.ticket.status.toUpperCase()})"
+      message += "\n>##{result.ticket.id} #{result.ticket.subject} (#{result.ticket.status.toUpperCase()})"
       message += "\n>Priority: #{result.ticket.priority}"
       message += "\n>Type: #{result.ticket.type}"
       message += "\n>Updated: #{result.ticket.updated_at}"

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -165,24 +165,12 @@ module.exports = (robot) ->
 
   robot.hear /#([\d]+)/i, (msg) ->
     ticket_id = msg.match[1]
-<<<<<<< HEAD
     if process.env.HUBOT_ZENDESK_LISTEN
       msg.send "It sounds like you're referencing a Zendesk ticket, let me look that up for you..."
       zendesk_request_hear msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
         if result.error
           msg.send "Hmmm. I thought you were talking about a Zendesk ticket, but when I tried looking it up, I got an error: #{result.description}"
           return
-        message = "It sounds like you're referencing a Zendesk ticket, let me look that up for you..."
-        message += "\n##{result.ticket.id} #{result.ticket.subject} (#{result.ticket.status.toUpperCase()})"
+        message = "\n##{result.ticket.id} #{result.ticket.subject} (#{result.ticket.status.toUpperCase()})"
         message += "\n#{tickets_url}/#{result.ticket.id}"
         msg.send message
-=======
-    zendesk_request_hear msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
-      if result.error
-        msg.send "Hmmm. I thought you were talking about a Zendesk ticket, but when I tried looking it up, I got an error: #{result.description}"
-        return
-      message = "It sounds like you're referencing a Zendesk ticket, let me look that up for you..."
-      message += "\n>##{result.ticket.id} #{result.ticket.subject} (#{result.ticket.status.toUpperCase()})"
-      message += "\n>#{tickets_url}/#{result.ticket.id}"
-      msg.send message
->>>>>>> ddd180590ce53d597ba1b3c9ff5c61def0c02832

--- a/src/zendesk.coffee
+++ b/src/zendesk.coffee
@@ -7,17 +7,19 @@
 #   HUBOT_ZENDESK_SUBDOMAIN
 #
 # Commands:
-#   hubot zendesk (all) tickets - returns the total count of all unsolved tickets. The 'all' keyword is optional.
-#   hubot zendesk new tickets - returns the count of all new (unassigned) tickets
-#   hubot zendesk open tickets - returns the count of all open tickets
-#   hubot zendesk escalated tickets - returns a count of tickets with escalated tag that are open or pending
-#   hubot zendesk pending tickets - returns a count of tickets that are pending
-#   hubot zendesk list (all) tickets - returns a list of all unsolved tickets. The 'all' keyword is optional.
-#   hubot zendesk list new tickets - returns a list of all new tickets
-#   hubot zendesk list open tickets - returns a list of all open tickets
-#   hubot zendesk list pending tickets - returns a list of pending tickets
-#   hubot zendesk list escalated tickets - returns a list of escalated tickets
-#   hubot zendesk ticket <ID> - returns information about the specified ticket
+#   hubot zendesk (all) tickets - Returns the total count of all unsolved tickets. The 'all' keyword is optional.
+#   hubot zendesk new tickets - Returns the count of all new (unassigned) tickets.
+#   hubot zendesk open tickets - Returns the count of all open tickets.
+#   hubot zendesk escalated tickets - Returns a count of tickets with escalated tag that are open or pending.
+#   hubot zendesk pending tickets - Returns a count of tickets that are pending.
+#   hubot zendesk list (all) tickets - Returns a list of all unsolved tickets. The 'all' keyword is optional.
+#   hubot zendesk list new tickets - Returns a list of all new tickets.
+#   hubot zendesk list open tickets - Returns a list of all open tickets.
+#   hubot zendesk list pending tickets - Returns a list of pending tickets.
+#   hubot zendesk list escalated tickets - Returns a list of escalated tickets.
+#   hubot zendesk ticket <ID> - Returns information about the specified ticket.
+#   hubot zd <comands> - 'zd' can be substituted for 'zendesk' in any of the above comands.
+#   #<TicketNumber> - Listens for numbers following # and attempts to return information and a link to the Zendesk ticket. 
 
 sys = require 'sys' # Used for debugging
 tickets_url = "https://#{process.env.HUBOT_ZENDESK_SUBDOMAIN}.zendesk.com/tickets"
@@ -51,6 +53,30 @@ zendesk_request = (msg, url, handler) ->
             msg.send "Zendesk says: #{content.error.title}"
           else
             msg.send "Zendesk says: #{content.error}"
+          return
+
+        handler content
+
+zendesk_request_hear = (msg, url, handler) ->
+  zendesk_user = "#{process.env.HUBOT_ZENDESK_USER}"
+  zendesk_password = "#{process.env.HUBOT_ZENDESK_PASSWORD}"
+  auth = new Buffer("#{zendesk_user}:#{zendesk_password}").toString('base64')
+  zendesk_url = "https://#{process.env.HUBOT_ZENDESK_SUBDOMAIN}.zendesk.com/api/v2"
+
+  msg.http("#{zendesk_url}/#{url}")
+    .headers(Authorization: "Basic #{auth}", Accept: "application/json")
+      .get() (err, res, body) ->
+        if err
+          msg.send "Hmmm. I thought you were talking about a zendesk ticket, but when I tried looking it up, I got an error: #{err}"
+          return
+
+        content = JSON.parse(body)
+
+        if content.error?
+          if content.error?.title
+            msg.send "Hmmm. I thought you were talking about a Zendesk ticket, but when I tried looking it up, I got an error: #{content.error.title}"
+          else
+            msg.send "Hmmm. I thought you were talking about a Zendesk ticket, but when I tried looking it up, I got an error: #{content.error}"
           return
 
         handler content
@@ -122,7 +148,10 @@ module.exports = (robot) ->
       if result.error
         msg.send result.description
         return
-      message = "#{tickets_url}/#{result.ticket.id} ##{result.ticket.id} (#{result.ticket.status.toUpperCase()})"
+      message = "#{tickets_url}/#{result.ticket.id}"
+      message += "\n>##{result.ticket.id} #(result.ticket.subject) (#{result.ticket.status.toUpperCase()})"
+      message += "\n>Priority: #{result.ticket.priority}"
+      message += "\n>Type: #{result.ticket.type}"
       message += "\n>Updated: #{result.ticket.updated_at}"
       message += "\n>Added: #{result.ticket.created_at}"
       message += "\n>Description:"
@@ -130,15 +159,13 @@ module.exports = (robot) ->
       message += "\n>#{result.ticket.description}"
       msg.send message
 
-  robot.hear /#([\d+)$/i, (msg) ->
+  robot.hear /#([\d+)/i, (msg) ->
     ticket_id = msg.match[1]
-    zendesk_requst msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
+    zendesk_request_hear msg, "#{queries.tickets}/#{ticket_id}.json", (result) ->
       if result.error
-        msg.send "Hmmm. I thought you were talking about a zendesk ticket, but when I tried looking it up, I got an error: #{result.description}"
+        msg.send "Hmmm. I thought you were talking about a Zendesk ticket, but when I tried looking it up, I got an error: #{result.description}"
         return
-      message = "It sounds like you're referencing a zendesk ticket, let me look that up for you..."
-      message += "\n{tickets_url}/#{result.ticket.id} ##{result.ticket.id} (#{result.ticket.status.toUpperCase()})"
-      message += "\n>Updated: #{result.ticket.updated_at}"
-      message += "\n>Added: #{result.ticket.created_at}"
-      message += "\n>Description: #{result.ticket.description}"
-
+      message = "It sounds like you're referencing a Zendesk ticket, let me look that up for you..."
+      message += "\n##{result.ticket.id} #{result.ticket.subject} (#{result.ticket.status.toUpperCase()})"
+      message += "\n#{tickets_url}/#{result.ticket.id}"
+      msg.send message


### PR DESCRIPTION
First, I wanted to say thanks for writing this. We plan on using this abundantly in our slack channel at my work. 

I added a license file (hope that was ok) to give you credit and add some legal protection about there being no warranty. 

Second, I really liked how the formatting for <hubot zd ticket 12345> looked (particularly in our slack channel) and noticed that the new line characters in the description didn't have the nice little indent, so I made a change to add a priority field and fix the formatting to match what you already had going on. 

Third, I thought it would be nice to have hubot listen for ticket numbers and provide a link. I realized later that people might not want that feature so I set it to activate with a variable. By default it will function the same, so users won't get annoyed with it. 

That's all for now. Thanks! 